### PR TITLE
feat: plugins (more convenient ux for external adapters)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ lcov.info
 .cargo/*
 !.cargo/audit.toml
 alembic.yml
+alembic.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ lcov.info
 # Local tool config
 .cargo/*
 !.cargo/audit.toml
-/alembic.toml
+/alembic.ymlg

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ lcov.info
 # Local tool config
 .cargo/*
 !.cargo/audit.toml
+/alembic.toml

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ lcov.info
 # Local tool config
 .cargo/*
 !.cargo/audit.toml
-/alembic.ymlg
+alembic.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 httpmock = "0.7"
 tempfile = "3"
 futures = "0.3"
-figment = { version = "0.10", features = ["toml", "env"] }
+figment = { version = "0.10", features = ["yaml", "env"] }

--- a/alembic.yml
+++ b/alembic.yml
@@ -1,1 +1,0 @@
-plugins_dir: "../my-plugins/"

--- a/alembic.yml
+++ b/alembic.yml
@@ -1,0 +1,1 @@
+plugins_dir: "../my-plugins/"

--- a/crates/alembic-adapter-registry/src/lib.rs
+++ b/crates/alembic-adapter-registry/src/lib.rs
@@ -107,7 +107,7 @@ impl AdapterConfig {
         }
     }
 
-    fn from_env(plugins: &Vec<Plugin>, backend: &str) -> Result<Self> {
+    fn from_env(plugins: &[Plugin], backend: &str) -> Result<Self> {
         match backend.to_lowercase().as_str() {
             "netbox" => Ok(AdapterConfig::Netbox(NetboxConfig {
                 url: None,
@@ -435,7 +435,7 @@ pub struct Plugin {
 }
 
 pub fn create_adapter(
-    plugins: &Vec<Plugin>,
+    plugins: &[Plugin],
     backend: Option<&str>,
     config_path: Option<PathBuf>,
 ) -> Result<Box<dyn Adapter>> {
@@ -457,7 +457,7 @@ pub fn create_adapter(
         if let Some(plugin) = plugins.iter().find(|p| p.name == backend) {
             load_config(&plugin.path)?
         } else {
-            AdapterConfig::from_env(&plugins, backend)?
+            AdapterConfig::from_env(plugins, backend)?
         }
     };
 
@@ -465,7 +465,7 @@ pub fn create_adapter(
 }
 
 fn load_config(path: &PathBuf) -> Result<AdapterConfig> {
-    let content = fs::read_to_string(&path)
+    let content = fs::read_to_string(path)
         .with_context(|| format!("read adapter config: {}", path.display()))?;
     let config: AdapterConfig = serde_yaml::from_str(&content)
         .with_context(|| format!("parse adapter config: {}", path.display()))?;

--- a/crates/alembic-adapter-registry/src/lib.rs
+++ b/crates/alembic-adapter-registry/src/lib.rs
@@ -107,7 +107,7 @@ impl AdapterConfig {
         }
     }
 
-    fn from_env(backend: &str) -> Result<Self> {
+    fn from_env(plugins: &Vec<Plugin>, backend: &str) -> Result<Self> {
         match backend.to_lowercase().as_str() {
             "netbox" => Ok(AdapterConfig::Netbox(NetboxConfig {
                 url: None,
@@ -136,8 +136,13 @@ impl AdapterConfig {
                 timeout_seconds: None,
             })),
             other => Err(anyhow!(
-                "unsupported backend {other} (expected one of: {})",
-                SUPPORTED_BACKENDS.join(", ")
+                "unsupported backend {other} (expected one of: {}; OR one of the plugins: {})",
+                SUPPORTED_BACKENDS.join(", "),
+                plugins
+                    .iter()
+                    .map(|p| p.name.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             )),
         }
     }
@@ -418,15 +423,24 @@ impl InfrahubSchemaConfig {
     }
 }
 
+/// A plugin is an external backend that can be
+/// referred to using its name instead of passing
+/// `--backend external --backend-config <path>` manually.
+#[derive(Debug)]
+pub struct Plugin {
+    /// should match the name passed to `--backend` flag
+    pub name: String,
+    /// path to the backend config yaml file that describes the plugin
+    pub path: PathBuf,
+}
+
 pub fn create_adapter(
+    plugins: &Vec<Plugin>,
     backend: Option<&str>,
     config_path: Option<PathBuf>,
 ) -> Result<Box<dyn Adapter>> {
     let config = if let Some(path) = config_path {
-        let content = fs::read_to_string(&path)
-            .with_context(|| format!("read adapter config: {}", path.display()))?;
-        let config: AdapterConfig = serde_yaml::from_str(&content)
-            .with_context(|| format!("parse adapter config: {}", path.display()))?;
+        let config = load_config(&path)?;
         if let Some(backend) = backend {
             if backend.to_lowercase() != config.backend_name() {
                 return Err(anyhow!(
@@ -439,10 +453,23 @@ pub fn create_adapter(
     } else {
         let backend =
             backend.ok_or_else(|| anyhow!("--backend or --backend-config is required"))?;
-        AdapterConfig::from_env(backend)?
+
+        if let Some(plugin) = plugins.iter().find(|p| p.name == backend) {
+            load_config(&plugin.path)?
+        } else {
+            AdapterConfig::from_env(&plugins, backend)?
+        }
     };
 
     config.build()
+}
+
+fn load_config(path: &PathBuf) -> Result<AdapterConfig> {
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("read adapter config: {}", path.display()))?;
+    let config: AdapterConfig = serde_yaml::from_str(&content)
+        .with_context(|| format!("parse adapter config: {}", path.display()))?;
+    Ok(config)
 }
 
 pub fn resolve_credentials(

--- a/crates/alembic-adapter-registry/src/lib.rs
+++ b/crates/alembic-adapter-registry/src/lib.rs
@@ -136,13 +136,20 @@ impl AdapterConfig {
                 timeout_seconds: None,
             })),
             other => Err(anyhow!(
-                "unsupported backend {other} (expected one of: {}; OR one of the plugins: {})",
+                "unsupported backend {other} (expected one of: {}{})",
                 SUPPORTED_BACKENDS.join(", "),
-                plugins
-                    .iter()
-                    .map(|p| p.name.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                if plugins.is_empty() {
+                    "".to_string()
+                } else {
+                    format!(
+                        "; OR one of the plugins: {}",
+                        plugins
+                            .iter()
+                            .map(|p| p.name.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                }
             )),
         }
     }
@@ -454,7 +461,7 @@ pub fn create_adapter(
         let backend =
             backend.ok_or_else(|| anyhow!("--backend or --backend-config is required"))?;
 
-        if let Some(plugin) = plugins.iter().find(|p| p.name == backend) {
+        if let Some(plugin) = plugins.iter().find(|p| p.name == backend.to_lowercase()) {
             load_config(&plugin.path)?
         } else {
             AdapterConfig::from_env(plugins, backend)?

--- a/crates/alembic-cli/src/app/config.rs
+++ b/crates/alembic-cli/src/app/config.rs
@@ -1,8 +1,8 @@
 //! configuration for the cli tool
 
-use figment::providers::Serialized;
+use figment::providers::{Serialized, Yaml};
 use figment::{
-    providers::{Env, Format, Toml},
+    providers::{Env, Format},
     Figment,
 };
 use serde::{Deserialize, Serialize};
@@ -18,7 +18,7 @@ pub struct AppConfig {
 impl AppConfig {
     fn figment() -> Figment {
         Figment::from(Serialized::defaults(Self::default()))
-            .merge(Toml::file("alembic.toml"))
+            .merge(Yaml::file("alembic.yml"))
             .merge(Env::prefixed("ALEMBIC_"))
     }
 

--- a/crates/alembic-cli/src/app/config.rs
+++ b/crates/alembic-cli/src/app/config.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct AppConfig {
-    pub plugin_dir: PathBuf,
+    pub plugins_dir: PathBuf,
 }
 
 impl AppConfig {
@@ -33,7 +33,7 @@ impl AppConfig {
 impl Default for AppConfig {
     fn default() -> AppConfig {
         AppConfig {
-            plugin_dir: "./plugins".into(),
+            plugins_dir: "./plugins".into(),
         }
     }
 }

--- a/crates/alembic-cli/src/app/config.rs
+++ b/crates/alembic-cli/src/app/config.rs
@@ -18,6 +18,7 @@ pub struct AppConfig {
 impl AppConfig {
     fn figment() -> Figment {
         Figment::from(Serialized::defaults(Self::default()))
+            .merge(Yaml::file("alembic.yaml"))
             .merge(Yaml::file("alembic.yml"))
             .merge(Env::prefixed("ALEMBIC_"))
     }

--- a/crates/alembic-cli/src/app/mod.rs
+++ b/crates/alembic-cli/src/app/mod.rs
@@ -338,7 +338,7 @@ fn search_for_plugins(config: &AppConfig) -> Vec<Plugin> {
             e.path()
                 .extension()
                 .and_then(|s| s.to_str())
-                .map(|s| s == "yaml")
+                .map(|s| s.to_lowercase() == "yaml")
                 .unwrap_or(false)
         })
         .map(|e| Plugin {
@@ -347,7 +347,8 @@ fn search_for_plugins(config: &AppConfig) -> Vec<Plugin> {
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or_default()
-                .to_string(),
+                .to_string()
+                .to_lowercase(),
             path: e.path(),
         })
         .collect()

--- a/crates/alembic-cli/src/app/mod.rs
+++ b/crates/alembic-cli/src/app/mod.rs
@@ -327,8 +327,8 @@ pub(crate) async fn run(cli: Cli, config: AppConfig) -> Result<()> {
 }
 
 fn search_for_plugins(config: &AppConfig) -> Vec<Plugin> {
-    let Ok(dir_contents) = fs::read_dir(&config.plugin_dir) else {
-        tracing::debug!("plugin dir '{}' not found", config.plugin_dir.display());
+    let Ok(dir_contents) = fs::read_dir(&config.plugins_dir) else {
+        tracing::debug!("plugin dir '{}' not found", config.plugins_dir.display());
         return vec![];
     };
 

--- a/crates/alembic-cli/src/app/mod.rs
+++ b/crates/alembic-cli/src/app/mod.rs
@@ -6,12 +6,13 @@ mod diag;
 mod io;
 mod state;
 
-use alembic_adapter_registry::create_adapter;
+use alembic_adapter_registry::{create_adapter, Plugin};
 use alembic_engine::{
     apply_plan, build_plan, compile_retort, is_brew_format, load_raw_yaml, load_retort, Plan,
 };
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
+use std::fs;
 use std::path::PathBuf;
 
 use self::cast_django::{run_cast_django, CastDjangoConfig, CommandRunner};
@@ -133,7 +134,7 @@ fn confirm(prompt: &str) -> Result<bool> {
     Ok(matches!(input.trim().to_lowercase().as_str(), "y" | "yes"))
 }
 
-pub(crate) async fn run(cli: Cli, _config: AppConfig) -> Result<()> {
+pub(crate) async fn run(cli: Cli, config: AppConfig) -> Result<()> {
     match cli.command {
         Command::Validate { file, retort } => {
             let inventory = load_inventory(&file, retort.as_deref())?;
@@ -159,7 +160,8 @@ pub(crate) async fn run(cli: Cli, _config: AppConfig) -> Result<()> {
         } => {
             let inventory = load_inventory(&file, retort.as_deref())?;
             let mut state = load_state().await?;
-            let adapter = create_adapter(backend.as_deref(), backend_config)?;
+            let plugins = search_for_plugins(&config);
+            let adapter = create_adapter(&plugins, backend.as_deref(), backend_config)?;
             if provision {
                 let provision_report = adapter.ensure_schema(&inventory.schema).await?;
                 if !provision_report.is_empty() {
@@ -191,7 +193,8 @@ pub(crate) async fn run(cli: Cli, _config: AppConfig) -> Result<()> {
             interactive,
         } => {
             let mut state = load_state().await?;
-            let adapter = create_adapter(backend.as_deref(), backend_config)?;
+            let plugins = search_for_plugins(&config);
+            let adapter = create_adapter(&plugins, backend.as_deref(), backend_config)?;
             let plan = read_plan(&plan)?;
 
             if interactive {
@@ -283,7 +286,8 @@ pub(crate) async fn run(cli: Cli, _config: AppConfig) -> Result<()> {
                 .as_deref()
                 .ok_or_else(|| anyhow!("import requires a retort with schema"))?;
             let retort = load_retort(retort_path)?;
-            let adapter = create_adapter(backend.as_deref(), backend_config)?;
+            let plugins = search_for_plugins(&config);
+            let adapter = create_adapter(&plugins, backend.as_deref(), backend_config)?;
             let state = load_state().await?;
             let types: Vec<TypeName> = retort.schema.types.keys().map(TypeName::new).collect();
             let report =
@@ -320,6 +324,33 @@ pub(crate) async fn run(cli: Cli, _config: AppConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn search_for_plugins(config: &AppConfig) -> Vec<Plugin> {
+    let Ok(dir_contents) = fs::read_dir(&config.plugin_dir) else {
+        tracing::debug!("plugin dir '{}' not found", config.plugin_dir.display());
+        return vec![];
+    };
+
+    dir_contents
+        .flatten()
+        .filter(|e| {
+            e.path()
+                .extension()
+                .and_then(|s| s.to_str())
+                .map(|s| s == "yaml")
+                .unwrap_or(false)
+        })
+        .map(|e| Plugin {
+            name: e
+                .path()
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default()
+                .to_string(),
+            path: e.path(),
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/alembic-cli/src/app/mod.rs
+++ b/crates/alembic-cli/src/app/mod.rs
@@ -341,15 +341,18 @@ fn search_for_plugins(config: &AppConfig) -> Vec<Plugin> {
                 .map(|s| s.to_lowercase() == "yaml")
                 .unwrap_or(false)
         })
-        .map(|e| Plugin {
-            name: e
-                .path()
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or_default()
-                .to_string()
-                .to_lowercase(),
-            path: e.path(),
+        .filter_map(|e| {
+            let path = e.path();
+            let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
+                return None;
+            };
+            if name == "" {
+                return None;
+            }
+            Some(Plugin {
+                name: name.to_string().to_lowercase(),
+                path: e.path(),
+            })
         })
         .collect()
 }

--- a/crates/alembic-cli/src/app/mod.rs
+++ b/crates/alembic-cli/src/app/mod.rs
@@ -338,7 +338,7 @@ fn search_for_plugins(config: &AppConfig) -> Vec<Plugin> {
             e.path()
                 .extension()
                 .and_then(|s| s.to_str())
-                .map(|s| s.to_lowercase() == "yaml")
+                .map(|s| s.to_lowercase() == "yaml" || s.to_lowercase() == "yml")
                 .unwrap_or(false)
         })
         .filter_map(|e| {

--- a/crates/alembic-cli/src/app/mod.rs
+++ b/crates/alembic-cli/src/app/mod.rs
@@ -343,10 +343,8 @@ fn search_for_plugins(config: &AppConfig) -> Vec<Plugin> {
         })
         .filter_map(|e| {
             let path = e.path();
-            let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
-                return None;
-            };
-            if name == "" {
+            let name = path.file_stem().and_then(|s| s.to_str())?;
+            if name.is_empty() {
                 return None;
             }
             Some(Plugin {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,23 @@ env:
 timeout_seconds: 60
 ```
 
-if you don't want a config file, you can pass `--backend <name>` and supply credentials via environment variables.
+if you don't want a config file, you can pass `--backend <name>` and
+supply credentials via environment variables.
+
+## plugins
+
+As a convenience, external adapter configs can be kept in a common
+directory (default: `plugins` in the working directory, see
+`docs/configuration.md` for how to change that). By passing the
+filename of such a config as the `--backend`, that backend config is
+automatically used.
+
+For example, if there's a backend config for a custom external adapter
+in `./plugins/my_adapter.yaml`; here's how to run it:
+
+```bash
+$ alembic apply --backend my_adapter
+```
 
 ## plan
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ The alembic cli tool can be configured using a layered set of
 configuration sources, applied in the following order:
 
 1. Built in app defaults
-2. Keys set in `alembic.toml` (file placed in working directory)
+2. Keys set in `alembic.yml` (file placed in working directory)
 3. Environment variables with the prefix "ALEMBIC_"
 
 ## Available configuration keys
@@ -14,10 +14,10 @@ configuration sources, applied in the following order:
 
 ## Examples
 
-To set a path where to look for plugins, you can use an `alembic.toml`
+To set a path where to look for plugins, you can use an `alembic.yml`
 config file in your working directory:
 
-```toml
+```yaml
 plugins_dir="/home/user/alembic_plugins"
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,28 @@
+# configuration
+
+The alembic cli tool can be configured using a layered set of
+configuration sources, applied in the following order:
+
+1. Built in app defaults
+2. Keys set in `alembic.toml` (file placed in working directory)
+3. Environment variables with the prefix "ALEMBIC_"
+
+## Available configuration keys
+
+- `plugins_dir` where the alembic cli will look for plugin
+  configuration files (which must have the file ending `.yaml`).
+
+## Examples
+
+To set a path where to look for plugins, you can use an `alembic.toml`
+config file in your working directory:
+
+```toml
+plugins_dir="/home/user/alembic_plugins"
+```
+
+Same setting but using an environment variable:
+
+```bash
+export ALEMBIC_PLUGINS_DIR="/home/user/alembic_plugins"
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ The alembic cli tool can be configured using a layered set of
 configuration sources, applied in the following order:
 
 1. Built in app defaults
-2. Keys set in `alembic.yml` (file placed in working directory)
+2. Keys set in `alembic.yaml` (file placed in working directory)
 3. Environment variables with the prefix "ALEMBIC_"
 
 ## Available configuration keys
@@ -14,7 +14,7 @@ configuration sources, applied in the following order:
 
 ## Examples
 
-To set a path where to look for plugins, you can use an `alembic.yml`
+To set a path where to look for plugins, you can use an `alembic.yaml`
 config file in your working directory:
 
 ```yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ this directory contains the canonical documentation for alembic.
 - `docs/plan.md` - plan json schema and semantics
 - `docs/state.md` - state store format and behavior
 - `docs/cli.md` - cli usage and examples
+- `docs/configuration.md` - cli configuration
 - `docs/cast.md` - django app generation from a brew inventory
 - `docs/netbox.md` - netbox adapter mapping and constraints
 - `docs/nautobot.md` - nautobot adapter mapping and constraints


### PR DESCRIPTION
With a properly configured plugins directory, this PR enables:

```alembic apply --backend containerlab ...```

which makes external adapters appear exactly like the built-in ones.

Plugins are loaded from the dir set in the cli app config, using the key `plugins_dir`(or environment variable `ALEMBIC_PLUGINS_DIR`. The backend name passed to --backend has to match the config file names (except the .toml file ending).
