### PR TITLE
deps: httpmock 0.8 (body_contains -> body_includes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 netbox = "0.5.4"
-nautobot = "0.3.1"
-infrahub = "0.1.0"
-reqwest = { version = "0.12", features = ["json"] }
+nautobot = "0.4.1"
+infrahub = "0.3.0"
+reqwest = { version = "0.13", features = ["json"] }
 regex = "1"
 ipnet = "2"
 tokio-postgres = "0.7"
@@ -50,7 +50,7 @@ native-tls = "0.2"
 postgres-native-tls = "0.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-httpmock = "0.7"
+httpmock = "0.8"
 tempfile = "3"
 futures = "0.3"
 figment = { version = "0.10", features = ["yaml", "env"] }

--- a/crates/alembic-adapter-infrahub/src/lib.rs
+++ b/crates/alembic-adapter-infrahub/src/lib.rs
@@ -2516,7 +2516,7 @@ schema { query: Query }
         let repo_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/graphql")
-                .body_contains("CoreRepository");
+                .body_includes("CoreRepository");
             then.status(200).json_body(json!({
                 "data": {
                     "CoreRepository": { "edges": [ { "node": { "id": "repo-1" } } ] }
@@ -2527,7 +2527,7 @@ schema { query: Query }
         let process_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/graphql")
-                .body_contains("InfrahubRepositoryProcess");
+                .body_includes("InfrahubRepositoryProcess");
             then.status(200).json_body(json!({
                 "data": {
                     "InfrahubRepositoryProcess": { "ok": true, "task": { "id": "task-1" } }
@@ -2570,7 +2570,7 @@ schema { query: Query }
         server.mock(|when, then| {
             when.method(POST)
                 .path("/graphql")
-                .body_contains("DcimSite");
+                .body_includes("DcimSite");
             then.status(200).json_body(json!({
                 "data": {
                     "DcimSite": {
@@ -2611,21 +2611,21 @@ schema { query: Query }
             then.status(200).body(GRAPHQL_SCHEMA);
         });
         server.mock(|when, then| {
-            when.method(POST).path("/graphql").body_contains("Create");
+            when.method(POST).path("/graphql").body_includes("Create");
             then.status(200).json_body(json!({
                 "data": { "DcimSiteCreate": { "ok": true, "object": { "id": "site-1" } } },
                 "errors": []
             }));
         });
         server.mock(|when, then| {
-            when.method(POST).path("/graphql").body_contains("Update");
+            when.method(POST).path("/graphql").body_includes("Update");
             then.status(200).json_body(json!({
                 "data": { "DcimSiteUpdate": { "ok": true, "object": { "id": "site-2" } } },
                 "errors": []
             }));
         });
         server.mock(|when, then| {
-            when.method(POST).path("/graphql").body_contains("Delete");
+            when.method(POST).path("/graphql").body_includes("Delete");
             then.status(200).json_body(json!({
                 "data": { "DcimSiteDelete": { "ok": true } },
                 "errors": []
@@ -2697,7 +2697,7 @@ schema { query: Query }
         server.mock(|when, then| {
             when.method(POST)
                 .path("/graphql")
-                .body_contains("DcimSite");
+                .body_includes("DcimSite");
             then.status(200).json_body(json!({
                 "data": {
                     "DcimSite": {


### PR DESCRIPTION
Carries Dependabot #68's cargo bump plus the test migration: httpmock 0.8 renamed `When::body_contains` to `body_includes`. Test-only (infrahub adapter mocks).

Rebased on main. Verified locally: workspace `cargo clippy --all-targets --all-features -- -D warnings` clean, adapter tests pass. Supersedes #68.