### PR TITLE
ci: clear cargo-deny advisories and aws-lc-sys license

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -422,9 +422,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -2428,9 +2428,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,13 @@ allow = [
     "Unicode-DFS-2016",
     "CDLA-Permissive-2.0",
 ]
+exceptions = [
+    # aws-lc-sys vendors AWS-LC (a BoringSSL fork), whose license expression
+    # includes the OpenSSL license alongside ISC/Apache-2.0. It is pulled in
+    # transitively via rustls's default aws-lc-rs crypto provider. The OpenSSL
+    # license is acceptable for our use, so allow it for this crate only.
+    { name = "aws-lc-sys", allow = ["OpenSSL"] },
+]
 confidence-threshold = 0.8
 
 [bans]


### PR DESCRIPTION
`lint-and-analysis` (`cargo deny check`) is failing on `main` due to newly published RUSTSEC advisories pinned by `Cargo.lock`, plus an unlisted license. Not introduced by any code change.

## Fixes

**`Cargo.lock` — security bumps:**
- `aws-lc-rs` 1.15.4 → 1.17.0 (pulls `aws-lc-sys` 0.41.0 — fixes RUSTSEC-2026-0044..0048 in AWS-LC)
- `bytes` 1.11.0 → 1.11.1 (RUSTSEC-2026-0007)
- `rustls-webpki` 0.103.8 → 0.103.13 (RUSTSEC-2026-0104)

**`deny.toml`:** scoped OpenSSL-license exception for `aws-lc-sys` only (it vendors AWS-LC via rustls's default `aws-lc-rs` crypto provider).
