### PR TITLE
refactor: clean up netbox generic fk unwrapping

### DIFF
--- a/crates/alembic-adapter-netbox/src/netbox/ops.rs
+++ b/crates/alembic-adapter-netbox/src/netbox/ops.rs
@@ -14,7 +14,7 @@ use alembic_engine::{
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use netbox::{BulkDelete, QueryBuilder, Resource};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -531,26 +531,33 @@ impl Adapter for NetBoxAdapter {
 
 fn unwrap_generic_object_request(attrs: &mut JsonMap, type_name: &TypeName) -> Result<()> {
     for (attr_name, attr_value) in attrs.iter_mut() {
-        if netbox::is_generic_fk(type_name.as_str(), attr_name) {
-            if attr_value.is_array() {
-                let mut arr: Vec<Value> = Vec::new();
-                for a in attr_value.as_array().unwrap() {
-                    let generic_object_request =
-                        serde_json::from_value::<GenericObjectRequest>(a.clone())?;
-                    let json_uid = Uid::parse_str(&generic_object_request.object)?.to_string();
-                    arr.push(Value::String(json_uid));
-                }
-                *attr_value = Value::Array(arr);
-            } else {
-                let generic_object_request =
-                    serde_json::from_value::<GenericObjectRequest>(attr_value.clone())?;
-                let json_uid = Uid::parse_str(&generic_object_request.object)?.to_string();
-                *attr_value = Value::String(json_uid);
-            }
+        if !netbox::is_generic_fk(type_name.as_str(), attr_name) {
+            continue;
+        }
+        if let Some(items) = attr_value.as_array() {
+            let uids = items
+                .iter()
+                .map(|item| {
+                    generic_object_uid(item)
+                        .with_context(|| format!("generic foreign key {attr_name} on {type_name}"))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            *attr_value = Value::Array(uids.into_iter().map(Value::String).collect());
+        } else {
+            let uid = generic_object_uid(attr_value)
+                .with_context(|| format!("generic foreign key {attr_name} on {type_name}"))?;
+            *attr_value = Value::String(uid);
         }
     }
 
     Ok(())
+}
+
+/// resolves a netbox generic foreign key payload (`{object, object_id, object_type}`)
+/// down to the alembic uid carried in its `object` field.
+fn generic_object_uid(value: &Value) -> Result<String> {
+    let request: GenericObjectRequest = serde_json::from_value(value.clone())?;
+    Ok(Uid::parse_str(&request.object)?.to_string())
 }
 
 impl NetBoxAdapter {
@@ -1521,11 +1528,12 @@ fn collect_missing_refs(value: &Value, resolved: &BTreeMap<Uid, u64>, missing: &
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+/// a netbox generic foreign key payload. netbox also sends `object_id` (the
+/// backend pk) and `object_type`, but only `object` (the alembic uid) is needed;
+/// serde ignores the rest.
+#[derive(Debug, Deserialize)]
 struct GenericObjectRequest {
     object: String,
-    object_id: u128,
-    object_type: String,
 }
 
 #[cfg(test)]
@@ -1772,6 +1780,27 @@ mod test_normalization {
         assert_eq!(
             attrs["a_terminations"],
             json!(["81c0681f-7147-5efb-a42a-68900b05c58d"])
+        );
+    }
+
+    #[test]
+    fn test_unwrap_generic_object_request_scalar() {
+        let mut map = Map::new();
+        map.insert(
+            "a_terminations".to_string(),
+            json!({
+                "object": "81c0681f-7147-5efb-a42a-68900b05c58d",
+                "object_id": 1,
+                "object_type": "dcim.interface",
+            }),
+        );
+        let mut attrs: JsonMap = map.into_iter().collect::<BTreeMap<_, _>>().into();
+
+        let type_name = TypeName::new("dcim.cable".to_string());
+        unwrap_generic_object_request(&mut attrs, &type_name).unwrap();
+        assert_eq!(
+            attrs["a_terminations"],
+            json!("81c0681f-7147-5efb-a42a-68900b05c58d")
         );
     }
 


### PR DESCRIPTION
Follow-up cleanups to #57.

- replace `as_array().unwrap()` with an `if let Some(..)`, matching the existing write-path `wrap_as_generic_foreign_key` idiom — no `unwrap()` in library code (CLAUDE.md rule)
- add error context to the generic-fk parse/uid steps so a malformed payload names the attr + type
- slim `GenericObjectRequest` to the only field read (`object`); serde ignores `object_id`/`object_type`, which also drops the off-convention `u128`
- factor the per-item conversion into `generic_object_uid`, removing the array/scalar duplication
- add a test for the scalar (non-array) branch